### PR TITLE
kernel bias fix and cupti release method

### DIFF
--- a/analyzer/habitat/analysis/predictor.py
+++ b/analyzer/habitat/analysis/predictor.py
@@ -180,7 +180,7 @@ class Predictor:
                 merged['padding'][0]
                 if isinstance(merged['padding'], tuple) else merged['padding']
             ),
-            bias=(1 if merged['bias'] is not None else 0),
+            bias=(1 if merged.get('bias',None) != None else 0),
         )
 
         # 3. Call model to make prediction
@@ -214,7 +214,7 @@ class Predictor:
                 merged['padding'][0]
                 if isinstance(merged['padding'], tuple) else merged['padding']
             ),
-            bias=(1 if merged['bias'] is not None else 0),
+            bias=(1 if merged.get('bias',None) != None else 0),
         )
 
         # 3. Call model to make prediction
@@ -251,7 +251,7 @@ class Predictor:
             batch=effective_batch,
             in_features=merged['weight'][1],
             out_features=merged['weight'][0],
-            bias=(1 if merged['bias'] is not None else 0)
+            bias=(1 if merged.get('bias',None) != None else 0)
         )
 
         arguments = [arguments[x] for x in self.linear_pred.model.features]
@@ -293,7 +293,7 @@ class Predictor:
                 operation.arguments.kwargs,
             )
             arguments = dict(
-                bias=(1 if merged['bias'] is not None else 0),
+                bias=(1 if merged.get('bias',None) != None else 0),
                 bidirectional=(1 if merged['bidirectional'] else 0),
                 batch=merged['input'][1],  # We require the batch to be in position 1
                 seq_len=merged['input'][0],
@@ -310,7 +310,7 @@ class Predictor:
             )
             max_batch_size = max(operation.arguments.special['batch_sizes'])
             arguments = dict(
-                bias=(1 if merged['bias'] is not None else 0),
+                bias=(1 if merged.get('bias',None) != None else 0),
                 bidirectional=(1 if merged['bidirectional'] else 0),
                 batch=max_batch_size,
                 seq_len=merged['input'][0] // max_batch_size,

--- a/analyzer/setup.py
+++ b/analyzer/setup.py
@@ -47,8 +47,8 @@ INSTALL_REQUIRES = [
     "torch>=1.4.0",
     "pandas>=1.1.2",
     "tqdm>=4.49.0",
-    "nvidia-cuda-cupti-cu12",
-    "nvidia-cuda-runtime-cu12",
+    "nvidia-cuda-cupti-cu11==11.7.101",
+    "nvidia-cuda-runtime-cu11==11.7.99",
     "incremental"
 ]
 

--- a/analyzer/setup.py
+++ b/analyzer/setup.py
@@ -47,8 +47,8 @@ INSTALL_REQUIRES = [
     "torch>=1.4.0",
     "pandas>=1.1.2",
     "tqdm>=4.49.0",
-    "nvidia-cuda-cupti-cu11==11.7.101",
-    "nvidia-cuda-runtime-cu11==11.7.99",
+    "nvidia-cuda-cupti-cu12",
+    "nvidia-cuda-runtime-cu12",
     "incremental"
 ]
 

--- a/cpp/src/frontend/profiler.cpp
+++ b/cpp/src/frontend/profiler.cpp
@@ -39,5 +39,9 @@ std::vector<KernelInstance> profile(
   return kernels;
 }
 
+void release_cupti_hook(){
+  CuptiManager::instance().unloadCupti();
+}
+
 }
 }

--- a/cpp/src/frontend/profiler.h
+++ b/cpp/src/frontend/profiler.h
@@ -16,5 +16,6 @@ std::vector<cuda::KernelInstance> profile(std::function<void()> runnable);
 std::vector<cuda::KernelInstance> profile(
     std::function<void()> runnable, const std::string& metric);
 
+void release_cupti_hook();
 }
 }

--- a/cpp/src/habitat_cuda.cpp
+++ b/cpp/src/habitat_cuda.cpp
@@ -31,4 +31,8 @@ PYBIND11_MODULE(habitat_cuda, m) {
     .def("run_flop_test", [](size_t num_blocks, size_t threads_per_block) {
       habitat::cuda::diagnostics::run_flop_test(num_blocks, threads_per_block);
     }, py::arg("num_blocks") = 8192, py::arg("threads_per_block") = 256);
+  
+  m.def("release_cupti_hook",[](){
+    habitat::frontend::release_cupti_hook();
+  });
 }


### PR DESCRIPTION
- Fixed bug when kernel does not contain bias
- updated cuda cupti requirement to 12.1 (for cuda 11.8 it shows error CUPTI_ERROR_MULTIPLE_SUBSCRIBERS_NOT_SUPPORTED)
- added method to release cupti resources