### PR TITLE
Add alternative default paths to find CUPTI and NVPerf

### DIFF
--- a/cpp/cmake/FindCUPTI.cmake
+++ b/cpp/cmake/FindCUPTI.cmake
@@ -49,6 +49,8 @@ find_path(CUPTI_INCLUDE_DIR cupti.h
   ${CUPTI_CUDA_HOME}/include
   /usr/local/cuda/include
   /usr/local/cuda/extras/CUPTI/include
+  /opt/cuda/include
+  /opt/cuda/extras/CUPTI/include
 )
 
 find_library(CUPTI_LIBRARY cupti
@@ -58,6 +60,8 @@ find_library(CUPTI_LIBRARY cupti
   ${CUPTI_CUDA_HOME}/lib64
   /usr/local/cuda/lib64
   /usr/local/cuda/extras/CUPTI/lib64
+  /opt/cuda/lib64
+  /opt/cuda/extras/CUPTI/lib64
 )
 
 find_package_handle_standard_args(CUPTI

--- a/cpp/cmake/FindNVPerf.cmake
+++ b/cpp/cmake/FindNVPerf.cmake
@@ -47,6 +47,8 @@ find_library(NVPerf_HOST_LIBRARY nvperf_host
   ${CUPTI_CUDA_HOME}/lib64
   /usr/local/cuda/lib64
   /usr/local/cuda/extras/CUPTI/lib64
+  /opt/cuda/lib64
+  /opt/cuda/extras/CUPTI/lib64
 )
 
 find_library(NVPerf_TARGET_LIBRARY nvperf_target
@@ -56,6 +58,8 @@ find_library(NVPerf_TARGET_LIBRARY nvperf_target
   ${CUPTI_CUDA_HOME}/lib64
   /usr/local/cuda/lib64
   /usr/local/cuda/extras/CUPTI/lib64
+  /opt/cuda/lib64
+  /opt/cuda/extras/CUPTI/lib64
 )
 
 find_package_handle_standard_args(NVPerf


### PR DESCRIPTION
This PR adds alternate paths for CMake so that DeepView.Predict builds by default on other distributions including Arch Linux. 