### PR TITLE
deleted CUDA_TAG from release to pypi

### DIFF
--- a/.github/workflows/whl-build-ec2.yaml
+++ b/.github/workflows/whl-build-ec2.yaml
@@ -53,26 +53,18 @@ jobs:
       - name: Build Python3.8 wheel
         run: |
           ./build_scripts/build_wheel.sh python3.8
-        env:
-          CUDA_TAG: cu121
   
       - name: Build Python3.9 wheel
         run: |
           ./build_scripts/build_wheel.sh python3.9
-        env:
-          CUDA_TAG: cu121
  
       - name: Build Python3.10 wheel
         run: |
           ./build_scripts/build_wheel.sh python3.10
-        env:
-          CUDA_TAG: cu121
  
       - name: Build Python3.11 wheel
         run: |
           ./build_scripts/build_wheel.sh python3.11
-        env:
-          CUDA_TAG: cu121
  
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Delete CUDA_TAG from workflow to release to pypi.
Fix error:
 HTTPError: 400 Bad Request from https://test.pypi.org/legacy/          
'0.1.5+cu121' is an invalid value for Version. Error: Can't use PEP 440 local versions.