### PR TITLE
[RELEASE 0.1.6] Temporary disable sm_90

### DIFF
--- a/cpp/src/cuda/CMakeLists.txt
+++ b/cpp/src/cuda/CMakeLists.txt
@@ -34,5 +34,5 @@ target_compile_options(
     "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-gencode arch=compute_70,code=sm_70>"
     "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-gencode arch=compute_75,code=sm_75>"
     "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-gencode arch=compute_80,code=sm_80>"
-    "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-gencode arch=compute_90,code=sm_90>"
+    #"$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-gencode arch=compute_90,code=sm_90>"
 )


### PR DESCRIPTION
CUDA versions prior to 11.8 do not support compilation for compute capability 90. We wish to support the newest hardwares which use sm_90 but would also like to have some backward-compatibility. 

We release two versions:

- 0.1.6 - without the support for sm_90
- 0.1.6.1 - supports sm_90 but does not support CUDA versions prior to 11.8.

This PR targets the prior. 