### PR TITLE
[FIX SUPPORT sm90] Support for H100 

### DIFF
--- a/.github/workflows/whl-build-all.yaml
+++ b/.github/workflows/whl-build-all.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   create-habitat-index-html:
-    needs: [whl-build-cu113, whl-build-cu116, whl-build-cu117, whl-build-cu118, whl-build-cu121]
+    needs: [whl-build-cu118, whl-build-cu121]
     runs-on: [self-hosted]
     steps:
       - name: Configure AWS Credentials
@@ -21,186 +21,7 @@ jobs:
       - name: Upload to S3
         run: |
           aws s3 cp index.html s3://centml-releases/habitat/
-  whl-build-cu113:
-    runs-on: [self-hosted, cu113]
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.HABITAT_AWS_ACCESS_KEY }}
-          aws-region: ${{ secrets.HABITAT_AWS_REGION }}
-          aws-secret-access-key: ${{ secrets.HABITAT_AWS_SECRET_ACCESS_KEY }}
-
-      - name: Display host information
-        run: |
-          uname -a
-          hostname
-          pwd
-          id
-          ls -la
-      - name: Fetch repository
-        uses: actions/checkout@v4
-
-      - name: Build Python3.8 wheel
-        run: |
-          ./build_scripts/build_wheel.sh python3.8
-        env:
-          VERSION_CUDA_TAG: cu113
-          EXTRA_REQUIRES: nvidia-cuda-cupti-cu11==11.7.101,nvidia-cuda-runtime-cu11==11.7.99
-
-      - name: Build Python3.9 wheel
-        run: |
-          ./build_scripts/build_wheel.sh python3.9
-        env:
-          VERSION_CUDA_TAG: cu113
-          EXTRA_REQUIRES: nvidia-cuda-cupti-cu11==11.7.101,nvidia-cuda-runtime-cu11==11.7.99
- 
-      - name: Build Python3.10 wheel
-        run: |
-          ./build_scripts/build_wheel.sh python3.10
-        env:
-          VERSION_CUDA_TAG: cu113
-          EXTRA_REQUIRES: nvidia-cuda-cupti-cu11==11.7.101,nvidia-cuda-runtime-cu11==11.7.99
- 
-      - name: Build Python3.11 wheel
-        run: |
-          ./build_scripts/build_wheel.sh python3.11
-        env:
-          VERSION_CUDA_TAG: cu113
-          EXTRA_REQUIRES: nvidia-cuda-cupti-cu11==11.7.101,nvidia-cuda-runtime-cu11==11.7.99
-
-      - name: Upload wheels to S3
-        run: |
-          aws s3 cp analyzer/dist/ s3://centml-releases/habitat/wheels-cu113/ --recursive --exclude "*" --include "*.whl"
-      
-      - name: Create index.html
-        run: |
-          file_list=(analyzer/dist/*.whl)
-          formatted_file_list=$(basename -a ${file_list[@]})
-          python3 /home/builduser/create_index.py habitat_cu113 -f $formatted_file_list
-      - name: Upload index.html to S3
-        run: |
-          aws s3 cp index.html s3://centml-releases/habitat/wheels-cu113/
-  whl-build-cu116:
-    runs-on: [self-hosted, cu116]
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.HABITAT_AWS_ACCESS_KEY }}
-          aws-region: ${{ secrets.HABITAT_AWS_REGION }}
-          aws-secret-access-key: ${{ secrets.HABITAT_AWS_SECRET_ACCESS_KEY }}
-
-      - name: Display host information
-        run: |
-          uname -a
-          hostname
-          pwd
-          id
-          ls -la
-      - name: Fetch repository
-        uses: actions/checkout@v4
-
-      - name: Build Python3.8 wheel
-        run: |
-          ./build_scripts/build_wheel.sh python3.8
-        env:
-          VERSION_CUDA_TAG: cu116
-          EXTRA_REQUIRES: nvidia-cuda-cupti-cu11==11.7.101,nvidia-cuda-runtime-cu11==11.7.99
- 
-      - name: Build Python3.9 wheel
-        run: |
-          ./build_scripts/build_wheel.sh python3.9
-        env:
-          VERSION_CUDA_TAG: cu116
-          EXTRA_REQUIRES: nvidia-cuda-cupti-cu11==11.7.101,nvidia-cuda-runtime-cu11==11.7.99
- 
-      - name: Build Python3.10 wheel
-        run: |
-          ./build_scripts/build_wheel.sh python3.10
-        env:
-          VERSION_CUDA_TAG: cu116
-          EXTRA_REQUIRES: nvidia-cuda-cupti-cu11==11.7.101,nvidia-cuda-runtime-cu11==11.7.99
- 
-      - name: Build Python3.11 wheel
-        run: |
-          ./build_scripts/build_wheel.sh python3.11
-        env:
-          VERSION_CUDA_TAG: cu116
-          EXTRA_REQUIRES: nvidia-cuda-cupti-cu11==11.7.101,nvidia-cuda-runtime-cu11==11.7.99
-
-      - name: Upload wheels to S3
-        run: |
-          aws s3 cp analyzer/dist/ s3://centml-releases/habitat/wheels-cu116/ --recursive --exclude "*" --include "*.whl"
-      
-      - name: Create index.html
-        run: |
-          file_list=(analyzer/dist/*.whl)
-          formatted_file_list=$(basename -a ${file_list[@]})
-          python3 /home/builduser/create_index.py habitat_cu116 -f $formatted_file_list
-      - name: Upload index.html to S3
-        run: |
-          aws s3 cp index.html s3://centml-releases/habitat/wheels-cu116/
-  whl-build-cu117:
-    runs-on: [self-hosted, cu117]
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.HABITAT_AWS_ACCESS_KEY }}
-          aws-region: ${{ secrets.HABITAT_AWS_REGION }}
-          aws-secret-access-key: ${{ secrets.HABITAT_AWS_SECRET_ACCESS_KEY }}
           
-      - name: Display host information
-        run: |
-          uname -a
-          hostname
-          pwd
-          id
-          ls -la
-      - name: Fetch repository
-        uses: actions/checkout@v4
- 
-      - name: Build Python3.8 wheel
-        run: |
-          ./build_scripts/build_wheel.sh python3.8
-        env:
-          VERSION_CUDA_TAG: cu117
-          EXTRA_REQUIRES: nvidia-cuda-cupti-cu11==11.7.101,nvidia-cuda-runtime-cu11==11.7.99
-
-      - name: Build Python3.9 wheel
-        run: |
-          ./build_scripts/build_wheel.sh python3.9
-        env:
-          VERSION_CUDA_TAG: cu117
-          EXTRA_REQUIRES: nvidia-cuda-cupti-cu11==11.7.101,nvidia-cuda-runtime-cu11==11.7.99
-
-      - name: Build Python3.10 wheel
-        run: |
-          ./build_scripts/build_wheel.sh python3.10
-        env:
-          VERSION_CUDA_TAG: cu117
-          EXTRA_REQUIRES: nvidia-cuda-cupti-cu11==11.7.101,nvidia-cuda-runtime-cu11==11.7.99
-
-      - name: Build Python3.11 wheel
-        run: |
-          ./build_scripts/build_wheel.sh python3.11
-        env:
-          VERSION_CUDA_TAG: cu117
-          EXTRA_REQUIRES: nvidia-cuda-cupti-cu11==11.7.101,nvidia-cuda-runtime-cu11==11.7.99
-
-      - name: Upload wheels to S3
-        run: |
-          aws s3 cp analyzer/dist/ s3://centml-releases/habitat/wheels-cu117/ --recursive --exclude "*" --include "*.whl"
-      
-      - name: Create index.html
-        run: |
-          file_list=(analyzer/dist/*.whl)
-          formatted_file_list=$(basename -a ${file_list[@]})
-          python3 /home/builduser/create_index.py habitat_cu117 -f $formatted_file_list
-      - name: Upload index.html to S3
-        run: |
-          aws s3 cp index.html s3://centml-releases/habitat/wheels-cu117/
   whl-build-cu118:
     runs-on: [self-hosted, cu118]
     steps:
@@ -261,6 +82,7 @@ jobs:
       - name: Upload index.html to S3
         run: |
           aws s3 cp index.html s3://centml-releases/habitat/wheels-cu118/
+
   whl-build-cu121:
     runs-on: [self-hosted, cu121]
     steps:

--- a/cpp/src/cuda/CMakeLists.txt
+++ b/cpp/src/cuda/CMakeLists.txt
@@ -34,5 +34,5 @@ target_compile_options(
     "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-gencode arch=compute_70,code=sm_70>"
     "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-gencode arch=compute_75,code=sm_75>"
     "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-gencode arch=compute_80,code=sm_80>"
-    # "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-gencode arch=compute_90,code=sm_90>"
+    "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-gencode arch=compute_90,code=sm_90>"
 )


### PR DESCRIPTION
- Add support for H100
- Since H100 has compute capability 9.0 which is only supported for CUDA versions >= 11.8, we will discontinue the support for versions prior to that (CUDA < 11.8).
- For backward compatibility, we have the following wheels:
- https://centml-releases.s3.us-east-2.amazonaws.com/habitat/wheels-cu113/index.html
- https://centml-releases.s3.us-east-2.amazonaws.com/habitat/wheels-cu116/index.html
- https://centml-releases.s3.us-east-2.amazonaws.com/habitat/wheels-cu117/index.html